### PR TITLE
ppms added to Circles

### DIFF
--- a/src/MapChart.js
+++ b/src/MapChart.js
@@ -26,6 +26,61 @@ const MAX_SIZE = 67786;
 let totConf = 0;
 let totRec = 0;
 let totDead = 0;
+var countrypop = {};
+//straight from https://www.census.gov/newsroom/press-kits/2019/national-state-estimates.html:
+let statepop = {
+	    "Alabama, US":	4903185,
+"Alaska, US": 731545,
+"Arizona, US":	7278717,
+"Arkansas, US":	3017804,
+"California, US":	39512223,
+"Colorado, US":	5758736,
+"Connecticut, US":	3565287,
+"Delaware, US":	973764,
+"District of Columbia, US":	705749,
+"Florida, US":	21477737,
+"Georgia, US":	10617423,
+"Hawaii, US":	1415872,
+"Idaho, US":	1787065,
+"Illinois, US":	12671821,
+"Indiana, US":	6732219,
+"Iowa, US":	3155070,
+"Kansas, US":	2913314,
+"Kentucky, US":	4467673,
+"Louisiana, US":	4648794,
+"Maine, US":	1344212,
+"Maryland, US":	6045680,
+"Massachusetts, US":	6892503,
+"Michigan, US":	9986857,
+"Minnesota, US":	5639632,
+"Mississippi, US":	2976149,
+"Missouri, US":	6137428,
+"Montana, US":	1068778,
+"Nebraska, US":	1934408,
+"Nevada, US":	3080156,
+"New Hampshire, US":	1359711,
+"New Jersey, US":	8882190,
+"New Mexico, US":	2096829,
+"New York, US":	19453561,
+"North Carolina, US":	10488084,
+"North Dakota, US":	762062,
+"Ohio, US":	11689100,
+"Oklahoma, US":	3956971,
+"Oregon, US":	4217737,
+"Pennsylvania, US":	12801989,
+"Rhode Island, US":	1059361,
+"South Carolina, US":	5148714,
+"South Dakota, US":	884659,
+"Tennessee, US":	6829174,
+"Texas, US":	28995881,
+"Utah, US":	3205958,
+"Vermont, US":	623989,
+"Virginia, US":	8535519,
+"Washington, US":	7614893,
+"West Virginia, US":	1792147,
+"Wisconsin, US":	5822434,
+"Wyoming, US":	578759
+    };
 
 const rounded = num => {
   if (num > 1000000000) {
@@ -193,7 +248,6 @@ class MapChart extends React.Component {
         }
         that.state.setTotRec(totRec);
         for(let i = 0; i < recovered.length; i++) {
-          // console.log(recovered[i].size + ", " + minSize + ", " + maxSize);
           recoveredAbsByRowId[recovered[i].rowId] = recovered[i].size;
           recovered[i].size = (recovered[i].size - minSize) / (maxSize - minSize);
           recovered[i].momentumLast1 = recovered[i].size - (recovered[i].sizeMin1 - minSize) / (maxSize - minSize);
@@ -252,6 +306,21 @@ class MapChart extends React.Component {
         that.setState({});
       }
     });
+
+	  // Why can't I load this:
+    //Papa.parse("https://population.un.org/wpp/Download/Files/1_Indicators%20(Standard)/CSV_FILES/WPP2019_TotalPopulationBySex.csv", {
+	    // but this:?
+    Papa.parse("http://localhost:3000/covid19-map/WPP2019_TotalPopulationBySex.csv", {
+      download: true,
+      complete: function(results) {
+        for(let data of results.data) {
+		if (data[4] == "2020") {
+			console.log("Loaded 2020 data for " + data[1] + ": " + data[8]);
+			countrypop[data[1]] = data[8]*1000;
+		}
+	}
+      }
+    });
   }
 
   render() {
@@ -277,7 +346,7 @@ class MapChart extends React.Component {
           <option selected={that.state.momentum==="last7"} value="last7">Show change last 7 day</option>
         </Form.Control>
         <ReactBootstrapSlider value={this.state.factor} change={e => {this.setState({ factor: e.target.value, width: e.target.value / 10 });}} step={1} max={100} min={1} />
-        <Form.Check inline className="small" checked={that.state.jhmode} label={<span style={{color: "white", background: "black", padding: "0 3px"}}>Johns Hopkins Mode 🤔🤷</span>} type={"checkbox"} name={"a"} id={`inline-checkbox-2`}
+        <Form.Check inline className="small" checked={that.state.jhmode} label={<span>Johns Hopkins Mode </span>} type={"checkbox"} name={"a"} id={`inline-checkbox-2`}
                     onClick={() => {that.setState({jhmode: !that.state.jhmode, chart: "pie", factor: 20, momentum: "none"});}} />
       </div>
       {
@@ -382,7 +451,7 @@ class MapChart extends React.Component {
                 //  size = Math.log(size * 100000) / 25;
                 //}
                 return (<Marker coordinates={coordinates}>
-                  <circle r={Math.sqrt(size) * that.state.factor} fill={pos ? "#F008" : "#0F08"} />
+                  <circle r={isNaN(size)?0:Math.sqrt(size) * that.state.factor} fill={pos ? "#F008" : "#0F08"} />
                   <title>{`${name} - ${Math.abs(val)} ${pos ? "INCREASE" : "DECREASE"} in active(= confirmed-recovered) cases (excl. deceased)`}</title>
                   <text
                     textAnchor="middle"
@@ -398,17 +467,24 @@ class MapChart extends React.Component {
             that.state.momentum==="none" &&
             confirmed.map(({ rowId, name, coordinates, markerOffset, size, val }) => {
               let active = val - recoveredAbsByRowId[rowId] - deathsAbsByRowId [rowId];
+              let sPop = name.endsWith(", US")?statepop[name]:countrypop[name];
               if(that.state.jhmode) {
                 size = Math.log(size * 100000) / 25;
               }
               if(that.state.chart==="pill" || that.state.chart==="bar") {
                 size *= 10;
               }
+		      if (isNaN(sPop)) {
+			      console.log("Didn't find data for " + name);
+		      }
+		      else {
+			      console.log("CountryPop for " + name + ":" + sPop);
+		      }
               return (<Marker coordinates={coordinates}>
-                <rect style={that.state.chart==="pill" ? {display: "block", hover: {fill: "#F00"}} : {display: "none", hover: {fill: "#F00"}}} x={- size * that.state.factor / 2} y={-that.state.width/2*3} height={that.state.width*3} width={size * that.state.factor} fill="#F008" />
-                <rect style={that.state.chart==="bar" ? {display: "block", hover: {fill: "#F00"}} : {display: "none", hover: {fill: "#F00"}}} x={that.state.width * 3 * 0 - that.state.width * 3 * 1.5} y={-size * that.state.factor} width={that.state.width * 3} height={size * that.state.factor} fill="#F008" />
-                <circle style={that.state.chart==="pie" ? {display: "block", hover: {fill: "#F00"}} : {display: "none", hover: {fill: "#F00"}}} r={Math.sqrt(size) * that.state.factor} fill="#F008" />
-                <title>{`${name} - ${val} confirmed, ${active} active`}</title>
+                <rect style={that.state.chart==="pill" ? {display: "block", hover: {fill: "#F00"}} : {display: "none", hover: {fill: "#F00"}}} x={isNaN(size)?0:- size * that.state.factor / 2} y={-that.state.width/2*3} height={that.state.width*3} width={isNaN(size)?0:size * that.state.factor} fill="#F008" />
+                <rect style={that.state.chart==="bar" ? {display: "block", hover: {fill: "#F00"}} : {display: "none", hover: {fill: "#F00"}}} x={that.state.width * 3 * 0 - that.state.width * 3 * 1.5} y={isNaN(size)?0:-size * that.state.factor} width={that.state.width * 3} height={isNaN(size)?0:size * that.state.factor} fill="#F008" />
+                <circle style={that.state.chart==="pie" ? {display: "block", hover: {fill: "#F00"}} : {display: "none", hover: {fill: "#F00"}}} r={isNaN(size)?0:Math.sqrt(size) * that.state.factor} fill="#F008" />
+                <title>{`${name} - ${val} confirmed (`+Math.round(1000000*val/sPop)+ `ppm), ${active} active`}</title>
                 <text
                   textAnchor="middle"
                   y={markerOffset}
@@ -422,6 +498,7 @@ class MapChart extends React.Component {
           {
             that.state.momentum==="none" && !that.state.jhmode &&
             recovered.map(({rowId, name, coordinates, markerOffset, size, val }) => {
+              let sPop = name.endsWith(", US")?statepop[name]:countrypop[name];
               if(that.state.jhmode) {
                 size = Math.log(size * 100000) / 25;
               }
@@ -431,11 +508,17 @@ class MapChart extends React.Component {
               if(that.state.chart==="pill" || that.state.chart==="bar") {
                 size *= 10;
               }
+		      if (isNaN(sPop)) {
+			      console.log("Didn't find data for " + name);
+		      }
+		      else {
+			      console.log("CountryPop for " + name + ":" + sPop);
+		      }
               return (<Marker coordinates={coordinates}>
-                <rect style={that.state.chart==="pill" ? {display: "block", hover: {fill: "#0F0"}} : {display: "none", hover: {fill: "#0F0"}}} x={- size * that.state.factor / 2} y={-that.state.width/2*3} height={that.state.width*3} width={size * that.state.factor} fill="#0F08" />
-                <rect style={that.state.chart==="bar" ? {display: "block", hover: {fill: "#0F0"}} : {display: "none", hover: {fill: "#0F0"}}} x={that.state.width * 3 * 1 - that.state.width * 3 * 1.5} y={-size * that.state.factor} width={that.state.width * 3} height={size * that.state.factor} fill="#0F08" />
-                <circle style={that.state.chart==="pie" ? {display: "block", hover: {fill: "#0F0"}} : {display: "none", hover: {fill: "#0F0"}}} r={Math.sqrt(size) * that.state.factor} fill="#0F08" />
-                <title>{name + " - " + val + " recovered"}</title>
+                <rect style={that.state.chart==="pill" ? {display: "block", hover: {fill: "#0F0"}} : {display: "none", hover: {fill: "#0F0"}}} x={isNaN(size)?0:- size * that.state.factor / 2} y={-that.state.width/2*3} height={that.state.width*3} width={isNaN(size)?0:size * that.state.factor} fill="#0F08" />
+                <rect style={that.state.chart==="bar" ? {display: "block", hover: {fill: "#0F0"}} : {display: "none", hover: {fill: "#0F0"}}} x={that.state.width * 3 * 1 - that.state.width * 3 * 1.5} y={isNaN(size)?0:-size * that.state.factor} width={that.state.width * 3} height={isNaN(size)?0:size * that.state.factor} fill="#0F08" />
+                <circle style={that.state.chart==="pie" ? {display: "block", hover: {fill: "#0F0"}} : {display: "none", hover: {fill: "#0F0"}}} r={isNaN(size)?0:Math.sqrt(size) * that.state.factor} fill="#0F08" />
+                <title>{name + " - " + val + " recovered ("+Math.round(1000000*val/sPop)+ "ppm)"}</title>
                 <text
                   textAnchor="middle"
                   y={markerOffset}
@@ -449,6 +532,7 @@ class MapChart extends React.Component {
           {
             that.state.momentum==="none" && !that.state.jhmode &&
             deaths.map(({name, coordinates, markerOffset, size, val }) => {
+              let sPop = name.endsWith(", US")?statepop[name]:countrypop[name];
               if(that.state.jhmode) {
                 size = Math.log(size * 100000) / 25;
               }
@@ -456,10 +540,10 @@ class MapChart extends React.Component {
                 size *= 10;
               }
               return (<Marker coordinates={coordinates}>
-                <rect style={that.state.chart==="pill" ? {display: "block", hover: {fill: "#000"}} : {display: "none", hover: {fill: "#000"}}} x={- size * that.state.factor / 2} y={-that.state.width/2*3} height={that.state.width*3} width={size * that.state.factor} fill="#000" />
-                <rect style={that.state.chart==="bar" ? {display: "block", hover: {fill: "#000"}} : {display: "none", hover: {fill: "#000"}}} x={that.state.width * 3 * 2 - that.state.width * 3 * 1.5} y={-size * that.state.factor} width={that.state.width * 3} height={size * that.state.factor} fill="#000" />
-                <circle style={that.state.chart==="pie" ? {display: "block", hover: {fill: "#000"}} : {display: "none", hover: {fill: "#2128"}}} r={Math.sqrt(size) * that.state.factor} fill="#2128" />
-                <title>{name + " - " + val + " deceased"}</title>
+                <rect style={that.state.chart==="pill" ? {display: "block", hover: {fill: "#000"}} : {display: "none", hover: {fill: "#000"}}} x={isNaN(size)?0:- size * that.state.factor / 2} y={-that.state.width/2*3} height={that.state.width*3} width={isNaN(size)?0:size * that.state.factor} fill="#000" />
+                <rect style={that.state.chart==="bar" ? {display: "block", hover: {fill: "#000"}} : {display: "none", hover: {fill: "#000"}}} x={that.state.width * 3 * 2 - that.state.width * 3 * 1.5} y={isNaN(size)?0:-size * that.state.factor} width={that.state.width * 3} height={isNaN(size)?0:size * that.state.factor} fill="#000" />
+                <circle style={that.state.chart==="pie" ? {display: "block", hover: {fill: "#000"}} : {display: "none", hover: {fill: "#2128"}}} r={isNaN(size)?0:Math.sqrt(size) * that.state.factor} fill="#2128" />
+                <title>{name + " - " + val + " deceased ("+Math.round(1000000*val/sPop)+ "ppm)"}</title>
                 <text
                   textAnchor="middle"
                   y={markerOffset}


### PR DESCRIPTION
As per your Slack suggestion, here's a (draft) PR with (most) country and state populations used to compute relative impact sizes. I added this as ppm numbers to the Circles visualisation. It would be much cooler to do another visualisation giving these relative numbers at 'one glance' -- but that I'd definitely leave to you as I don't want to mess with your main data structures (and I'd have to learn much more than what this little "JS-refresher-project-after-10-years-hiatus" did :-)

Caveat: This only works when the UN population data is pulled off my dev server but not when trying to retrieve it from the UN server: Do you have an idea what I'm doing wrong (t)here? Hence only 'draft'.

I also added quite a few `NaN` checks into your code to eliminate loads of JS warnings.